### PR TITLE
gitignore; use full url in dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 components
 build
+node_modules

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"iswindow": "https://github.com/ubergrape/iswindow.git#a00e54ba827a7e65d6723792be2e66910d654c59"
+		"iswindow": "https://github.com/ubergrape/iswindow.git"
 	},
 	"license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	],
 	"main": "index.js",
 	"dependencies": {
-		"iswindow": "ubergrape/iswindow"
+		"iswindow": "https://github.com/ubergrape/iswindow.git#a00e54ba827a7e65d6723792be2e66910d654c59"
 	},
 	"license": "MIT"
 }


### PR DESCRIPTION
This is a fix for npm3 + shrinkwrap. We need to use the full url form for shrinkwrap to work properly.